### PR TITLE
fix: remove wagmi from prohibited packages list

### DIFF
--- a/src/lib/utils/checkForProhibitedPackages/checkForProhibitedPackages.ts
+++ b/src/lib/utils/checkForProhibitedPackages/checkForProhibitedPackages.ts
@@ -11,7 +11,6 @@ const listOfProhibitedPackages = [
   '@onflow/fcl',
   '@randlabs/myalgo-connect',
   '@wagmi/core',
-  'wagmi',
   '@walletconnect/client',
   '@walletconnect/ethereum-provider',
   '@walletconnect/universal-provider',


### PR DESCRIPTION
It removes wagmi from list of prohibited packages