### PR TITLE
feat: add bun support

### DIFF
--- a/src/lib/utils/getInstalledPackages/getInstalledPackages.ts
+++ b/src/lib/utils/getInstalledPackages/getInstalledPackages.ts
@@ -1,4 +1,5 @@
 import { execSync } from 'child_process';
+import { getPackageManager } from '../getPackageManager';
 
 const getPositionInLine = (
   string: string,
@@ -14,8 +15,11 @@ const packageNamesWithDifferentVersion = [
   '@dynamic-labs/sdk-api',
 ];
 
-export const getInstalledPackages = (): any =>
-  execSync('npm ls')
+export const getInstalledPackages = (): any => {
+  const command =
+    getPackageManager().packageManager === 'bun' ? 'bun pm ls' : 'npm ls';
+
+  return execSync(command)
     .toString()
     .split(/├──|└──|\+--|`--/)
     .slice(1)
@@ -40,3 +44,4 @@ export const getInstalledPackages = (): any =>
         [packageName]: version,
       };
     }, {});
+};

--- a/src/lib/utils/getPackageManager/getPackageManager.spec.ts
+++ b/src/lib/utils/getPackageManager/getPackageManager.spec.ts
@@ -29,6 +29,7 @@ describe('getPackageManager', () => {
     expect(mockExistsSync).toHaveBeenCalledWith('./package-lock.json');
     expect(mockExistsSync).not.toHaveBeenCalledWith('./yarn.lock');
     expect(mockExistsSync).not.toHaveBeenCalledWith('./pnpm-lock.yaml');
+    expect(mockExistsSync).not.toHaveBeenCalledWith('./bun.lockb');
     expect(mockGetPackageManagerVersion).toHaveBeenCalledWith(
       mockPackageManager,
     );
@@ -53,6 +54,7 @@ describe('getPackageManager', () => {
     expect(mockExistsSync).toHaveBeenCalledWith('./package-lock.json');
     expect(mockExistsSync).toHaveBeenCalledWith('./yarn.lock');
     expect(mockExistsSync).not.toHaveBeenCalledWith('./pnpm-lock.yaml');
+    expect(mockExistsSync).not.toHaveBeenCalledWith('./bun.lockb');
     expect(mockGetPackageManagerVersion).toHaveBeenCalledWith(
       mockPackageManager,
     );
@@ -77,6 +79,33 @@ describe('getPackageManager', () => {
     expect(mockExistsSync).toHaveBeenCalledWith('./package-lock.json');
     expect(mockExistsSync).toHaveBeenCalledWith('./yarn.lock');
     expect(mockExistsSync).toHaveBeenCalledWith('./pnpm-lock.yaml');
+    expect(mockExistsSync).not.toHaveBeenCalledWith('./bun.lockb');
+    expect(mockGetPackageManagerVersion).toHaveBeenCalledWith(
+      mockPackageManager,
+    );
+    expect(result).toEqual({
+      packageManager: mockPackageManager,
+      packageManagerVersion: mockPackageManagerVersion,
+    });
+  });
+
+  it('should return bun as the package manager', () => {
+    const mockPackageManager = 'bun';
+    const mockPackageManagerVersion = '1.0.1';
+
+    mockExistsSync
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true);
+    mockGetPackageManagerVersion.mockReturnValue(mockPackageManagerVersion);
+
+    const result = getPackageManager();
+
+    expect(mockExistsSync).toHaveBeenCalledWith('./package-lock.json');
+    expect(mockExistsSync).toHaveBeenCalledWith('./yarn.lock');
+    expect(mockExistsSync).toHaveBeenCalledWith('./pnpm-lock.yaml');
+    expect(mockExistsSync).toHaveBeenCalledWith('./bun.lockb');
     expect(mockGetPackageManagerVersion).toHaveBeenCalledWith(
       mockPackageManager,
     );

--- a/src/lib/utils/getPackageManager/getPackageManager.ts
+++ b/src/lib/utils/getPackageManager/getPackageManager.ts
@@ -4,15 +4,25 @@ import { getPackageManagerVersion } from './helpers/getPackageManagerVersion';
 const NPM_LOCK_PATH = './package-lock.json';
 const YARN_LOCK_PATH = './yarn.lock';
 const PNPM_LOCK_PATH = './pnpm-lock.yaml';
+const BUN_LOCK_PATH = './bun.lockb';
 
 const getPackageManagerFromPaths = () => {
   if (existsSync(NPM_LOCK_PATH)) {
     return 'npm';
-  } else if (existsSync(YARN_LOCK_PATH)) {
+  }
+
+  if (existsSync(YARN_LOCK_PATH)) {
     return 'yarn';
-  } else if (existsSync(PNPM_LOCK_PATH)) {
+  }
+
+  if (existsSync(PNPM_LOCK_PATH)) {
     return 'pnpm';
   }
+
+  if (existsSync(BUN_LOCK_PATH)) {
+    return 'bun';
+  }
+
   return 'unknown';
 };
 

--- a/src/lib/utils/isInProjectRoot/isInProjectRoot.spec.tsx
+++ b/src/lib/utils/isInProjectRoot/isInProjectRoot.spec.tsx
@@ -16,7 +16,8 @@ describe('isInProjectRoot', () => {
       .mockReturnValueOnce(true) // package.json exists
       .mockReturnValueOnce(true) // yarn.lock exists
       .mockReturnValueOnce(false) // package-lock.json does not exist
-      .mockReturnValueOnce(false); // pnpm-lock.yaml does not exist
+      .mockReturnValueOnce(false) // pnpm-lock.yaml does not exist
+      .mockReturnValueOnce(false); // bun.lockb does not exist
 
     const result = isInProjectRoot();
 
@@ -29,7 +30,8 @@ describe('isInProjectRoot', () => {
       .mockReturnValueOnce(true) // package.json exists
       .mockReturnValueOnce(false) // yarn.lock does not exist
       .mockReturnValueOnce(true) // package-lock.json exists
-      .mockReturnValueOnce(false); // pnpm-lock.yaml does not exist
+      .mockReturnValueOnce(false) // pnpm-lock.yaml does not exist
+      .mockReturnValueOnce(false); // bun.lockb does not exist
 
     const result = isInProjectRoot();
 
@@ -42,7 +44,22 @@ describe('isInProjectRoot', () => {
       .mockReturnValueOnce(true) // package.json exists
       .mockReturnValueOnce(false) // yarn.lock does not exist
       .mockReturnValueOnce(false) // package-lock.json exists
-      .mockReturnValueOnce(true); // pnpm-lock.yaml does exist
+      .mockReturnValueOnce(true) // pnpm-lock.yaml does exist
+      .mockReturnValueOnce(false); // bun.lockb does not exist
+
+    const result = isInProjectRoot();
+
+    expect(result).toBe(true);
+  });
+
+  it('should return true if all required files exist (using bun.lockb)', () => {
+    mockExistsSync
+      .mockReturnValueOnce(true) // node_modules exists
+      .mockReturnValueOnce(true) // package.json exists
+      .mockReturnValueOnce(false) // yarn.lock does not exist
+      .mockReturnValueOnce(false) // package-lock.json exists
+      .mockReturnValueOnce(false) // pnpm-lock.yaml does not exist
+      .mockReturnValueOnce(true); // bun.lockb does exist
 
     const result = isInProjectRoot();
 
@@ -54,8 +71,9 @@ describe('isInProjectRoot', () => {
       .mockReturnValueOnce(false) // node_modules does not exist
       .mockReturnValueOnce(true) // package.json exists
       .mockReturnValueOnce(false) // yarn.lock does not exist
-      .mockReturnValueOnce(false) // package-lock.json does not exists
-      .mockReturnValueOnce(false); // pnpm-lock.yaml does not exists
+      .mockReturnValueOnce(false) // package-lock.json does not exist
+      .mockReturnValueOnce(false) // pnpm-lock.yaml does not exist
+      .mockReturnValueOnce(false); // bun.lockb does not exist
 
     const result = isInProjectRoot();
 
@@ -78,7 +96,8 @@ describe('isInProjectRoot', () => {
       .mockReturnValueOnce(true) // package.json exists
       .mockReturnValueOnce(false) // yarn.lock does not exist
       .mockReturnValueOnce(false) // package-lock.json does not exist
-      .mockReturnValueOnce(false); // pnpm-lock.yaml does not exists
+      .mockReturnValueOnce(false) // pnpm-lock.yaml does not exist
+      .mockReturnValueOnce(false); // bun.lockb does not exist
 
     const result = isInProjectRoot();
 

--- a/src/lib/utils/isInProjectRoot/isInProjectRoot.ts
+++ b/src/lib/utils/isInProjectRoot/isInProjectRoot.ts
@@ -9,16 +9,21 @@ export const isInProjectRoot = () => {
   const yarnLockPath = join(directory, 'yarn.lock');
   const packageLockPath = join(directory, 'package-lock.json');
   const pnpmLockPath = join(directory, 'pnpm-lock.yaml');
+  const bunLockPath = join(directory, 'bun.lockb');
 
   const isNodeModulesInDirectory = existsSync(nodeModulesPath);
   const isPackageJsonInDirectory = existsSync(packageJsonPath);
   const isYarnLockInDirectory = existsSync(yarnLockPath);
   const isPackageLockInDirectory = existsSync(packageLockPath);
   const isPnpmLockInDirectory = existsSync(pnpmLockPath);
+  const isBunLockInDirectory = existsSync(bunLockPath);
 
   return (
     isNodeModulesInDirectory &&
     isPackageJsonInDirectory &&
-    (isYarnLockInDirectory || isPackageLockInDirectory || isPnpmLockInDirectory)
+    (isYarnLockInDirectory ||
+      isPackageLockInDirectory ||
+      isPnpmLockInDirectory ||
+      isBunLockInDirectory)
   );
 };


### PR DESCRIPTION
It adds a bun support to Dynamic Doctor. 

It will check for bun lock file inside checking if a user is running doctor in the project root and set a package manager to `bun` instead of `unknown`