### PR TITLE
fix: calling npm ls when user is using pnpm

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Create an issue if you find any bug or want to suggest an improvement. [Create a
 1. Install dependencies `yarn`
 2. Run `yarn build`
 3. Next pack local library `yarn pack`
-4. Install package `npm i -g dynamic-doctor-v0.0.4.tgz`
+4. Install package `npm i -g dynamic-doctor-v0.0.5.tgz`
 
 That's your setup!
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "bugs": {
     "url": "https://github.com/dynamic-labs/dynamic-doctor/issues"
   },
-  "version": "0.0.4",
+  "version": "0.0.5",
   "license": "MIT",
   "bin": {
     "dynamic-doctor": "./dist/index.js"

--- a/src/lib/utils/getInstalledPackages/getInstalledPackages.spec.ts
+++ b/src/lib/utils/getInstalledPackages/getInstalledPackages.spec.ts
@@ -121,4 +121,33 @@ describe('getInstalledPackages', () => {
       '@dynamic-labs/sdk-react': '0.18.8',
     });
   });
+
+  it('should use pnpm to check for packages', () => {
+    mockGetPackageManager.mockReturnValue({
+      packageManager: 'pnpm',
+      packageManagerVersion: '1.0.1',
+    });
+
+    const mockNpmLsOutput = `
+    Legend: production dependency, optional only, dev only
+
+    pnpm-test@1.0.0 /Users/bartosz.kownacki/Documents/repos/pnpm-test
+    
+    dependencies:
+    @dynamic-labs/sdk-api 0.0.321
+    @dynamic-labs/sdk-react-core 0.19.5
+    @dynamic-labs/wagmi-connector 0.19.5
+    typescript 5.3.2
+    `;
+
+    mockExecSync.mockReturnValue(Buffer.from(mockNpmLsOutput));
+
+    const result = getInstalledPackages();
+
+    expect(mockExecSync).toHaveBeenCalledWith('pnpm ls');
+    expect(result).toEqual({
+      '@dynamic-labs/sdk-react-core': '0.19.5',
+      '@dynamic-labs/wagmi-connector': '0.19.5',
+    });
+  });
 });


### PR DESCRIPTION
For some users when user is using pnpm dynamic doctor breaks when trying to run npm ls command. 
Right now when pnpm detected it will trigger pnpm ls and use custom filter command to get installed packages. 