### PR TITLE
fix: detect alpha version correctly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   node: circleci/node@5.1.0
-  sonarcloud: sonarsource/sonarcloud@1.1.1
+  sonarcloud: sonarsource/sonarcloud@2.0.0
 
 jobs:
   lint:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Create an issue if you find any bug or want to suggest an improvement. [Create a
 1. Install dependencies `yarn`
 2. Run `yarn build`
 3. Next pack local library `yarn pack`
-4. Install package `npm i -g dynamic-doctor-v0.0.5.tgz`
+4. Install package `npm i -g dynamic-doctor-v0.0.6.tgz`
 
 That's your setup!
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "bugs": {
     "url": "https://github.com/dynamic-labs/dynamic-doctor/issues"
   },
-  "version": "0.0.5",
+  "version": "0.0.6",
   "license": "MIT",
   "bin": {
     "dynamic-doctor": "./dist/index.js"


### PR DESCRIPTION
It fixes an issue with alpha version detection. 

Previously alpha versions were detected as outdated and dynamic-doctor was recommending to update to our latest version
<img width="1185" alt="image" src="https://github.com/dynamic-labs/dynamic-doctor/assets/107057105/fe95f233-3ca9-40d8-8441-255d8ed69085">


Right now it detects it correctly and shows latest alpha as valid version. If user is on outdated alpha it recommends using latest alpha version. 
It will also check if we already released a stable version if so it will suggest using a latest stable.

![image](https://github.com/dynamic-labs/dynamic-doctor/assets/107057105/ce724f4f-e88c-4b11-89d7-97f599f6b424)
![image](https://github.com/dynamic-labs/dynamic-doctor/assets/107057105/29b290b3-ec5c-4e5f-b171-1b5a51247ead)
